### PR TITLE
feat(redirect): add redirect to turso.tech

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 ---
 permalink: /404.html
 layout: default
+redirect_to: https://turso.tech/404.html
 ---
 
 <style type="text/css" media="screen">

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "minima", "~> 2.5"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
+  gem 'jekyll-redirect-from'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,8 @@ GEM
       terminal-table (~> 2.0)
     jekyll-feed (0.16.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.8.0)
@@ -68,11 +70,13 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.2.2)
   jekyll-feed (~> 0.12)
+  jekyll-redirect-from
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -30,9 +30,9 @@ github_username: libsql
 
 # Build settings
 theme: minima
-#plugins:
+plugins:
 #  - jekyll-feed
-
+  - jekyll-redirect-from
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/about.markdown
+++ b/about.markdown
@@ -2,6 +2,7 @@
 layout: default
 title: About
 permalink: /about
+redirect_to: https://turso.tech/libsql-manifesto
 ---
 
 # About libSQL

--- a/index.markdown
+++ b/index.markdown
@@ -1,5 +1,6 @@
 ---
 layout: default
+redirect_to: https://turso.tech/libsql
 ---
 
 ![libSQL logo](/images/favicon/apple-touch-icon.png)


### PR DESCRIPTION
While we don't have a better way to redirect we can add a client side redirect in the libsql website

This PR achieves these goals:

- This adds the jekyll-redirect-from plugin in the project which is allowed on github pages
- Adds the redirect to https://turso.tech from https://libsql.org
- Adds the redirect to https://turso.tech/libsql-manifesto from https://libsql.org/about

